### PR TITLE
belongs_to associations was not working

### DIFF
--- a/lib/simply_stored/couch/belongs_to.rb
+++ b/lib/simply_stored/couch/belongs_to.rb
@@ -56,9 +56,8 @@ module SimplyStored
           @options.assert_valid_keys(:class_name)
 
           owner_clazz.class_eval do
-            attr_reader "#{name}_id"
-            attr_accessor "#{name}_id_was"
-            property "#{name}_id"
+            attr_accessor :"#{name}_id_was"
+            property :"#{name}_id"
             
             define_method name do |*args|
               local_options = args.last.is_a?(Hash) ? args.last : {}

--- a/simply_stored.gemspec
+++ b/simply_stored.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     "CHANGELOG.md",
-     "Gemfile.lock",
      "LICENSE.txt",
      "README.md",
      "lib/simply_stored.rb",


### PR DESCRIPTION
The attr_accessor declarations were preventing the property declaration from working properly. Happened with environment:
- abstract (1.0.0)
- actionmailer (3.0.7)
- actionpack (3.0.7)
- activemodel (3.0.7)
- activerecord (3.0.7)
- activeresource (3.0.7)
- activesupport (3.0.7)
- arel (2.0.9)
- bcrypt-ruby (2.1.4)
- builder (2.1.2)
- bundler (1.0.7)
- columnize (0.3.2)
- couch_potato (0.5.2)
- couchrest (1.0.2)
- daemons (1.1.3)
- declarative_authorization (0.5.2)
- devise (1.3.3)
- erubis (2.6.6)
- eventmachine (0.12.10)
- haml (3.1.1)
- i18n (0.5.0)
- json (1.5.1)
- linecache (0.43)
- mail (2.2.19)
- mattmatt-validatable (1.8.4)
- mime-types (1.16)
- nokogiri (1.4.4)
- orm_adapter (0.0.4)
- polyglot (0.3.1)
- rack (1.2.2)
- rack-mount (0.6.14)
- rack-test (0.5.7)
- rails (3.0.7)
- railties (3.0.7)
- rake (0.8.7)
- rest-client (1.6.1)
- ruby-debug (0.10.4)
- ruby-debug-base (0.10.4)
- simply_stored (0.5.4)
- sqlite3 (1.3.3)
- thin (1.2.11)
- thor (0.14.6)
- treetop (1.4.9)
- tzinfo (0.3.26)
- warden (1.0.3)
- webrat (0.7.3)
