### PR TITLE
has_many not taking into account belongs_to foreign key fix

### DIFF
--- a/lib/simply_stored/couch/has_many.rb
+++ b/lib/simply_stored/couch/has_many.rb
@@ -61,7 +61,11 @@ module SimplyStored
           klass = self.class.get_class_from_name(name)
           raise ArgumentError, "expected #{klass} got #{value.class}" unless value.is_a?(klass)
           
-          value.send("#{self.class.foreign_key}=", id)
+          if !options[:foreign_key].blank?          
+            value.send("#{options[:foreign_key]}=", id)
+          else
+            value.send("#{self.class.foreign_key}=", id)
+          end
           value.save(false)
           
           cached_results = send("_get_cached_#{name}")[:all]


### PR DESCRIPTION
For example when having such a scenario

class Post
  include SimplyStored::Couch

  belongs_to :owner, :class_name => "User"
end

class User
  include SimplyStored::Couch

  has_many :creations, :foreign_key => "owner_id"

end

When wanting to add a post to a user by going user.add_post, an error will be thrown saying:
NoMethodError: undefined method `user_id='

This fix checks for a foreign_key in the options and sets that as the one to use. 
