### PR TITLE
Fix for not taking into account class_name in custom has_many

### DIFF
--- a/lib/simply_stored/couch/has_many.rb
+++ b/lib/simply_stored/couch/has_many.rb
@@ -58,7 +58,11 @@ module SimplyStored
       
       def define_has_many_setter_add(name, options)
         define_method("add_#{name.to_s.singularize}") do |value|
-          klass = self.class.get_class_from_name(name)
+          if !options[:class_name].blank?
+            klass = self.class.get_class_from_name(options[:class_name])
+          else
+            klass = self.class.get_class_from_name(name)          
+          end
           raise ArgumentError, "expected #{klass} got #{value.class}" unless value.is_a?(klass)
           
           value.send("#{self.class.foreign_key}=", id)


### PR DESCRIPTION
fix for this issue: https://github.com/peritor/simply_stored/issues/17
